### PR TITLE
Add Terraform Tycoon prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# robloxgame
+# Terraform Tycoon
+
+A prototype for an idle sci-fi planet builder game on Roblox. Players terraform micro-planets, grow alien flora, harvest Stardust and upgrade technology.
+
+This repository contains simple Lua modules demonstrating core mechanics:
+
+- `Planet.lua` – planet data and basic actions
+- `PlayerProfile.lua` – tracks player planets and prestige
+- `GameServer.lua` – minimal game server managing players
+- `init.lua` – example usage
+
+These scripts are not a full Roblox game but serve as a starting point for further development.

--- a/src/GameServer.lua
+++ b/src/GameServer.lua
@@ -1,0 +1,35 @@
+local PlayerProfile = require(script.PlayerProfile)
+
+local GameServer = {}
+GameServer.__index = GameServer
+
+function GameServer.new()
+    local self = setmetatable({}, GameServer)
+    self.Players = {}
+    return self
+end
+
+function GameServer:AddPlayer(player)
+    local profile = PlayerProfile.new(player)
+    self.Players[player] = profile
+    return profile
+end
+
+function GameServer:GetProfile(player)
+    return self.Players[player]
+end
+
+function GameServer:Tick()
+    -- This would be run each server tick to progress planets
+    for _, profile in pairs(self.Players) do
+        for _, planet in ipairs(profile.Planets) do
+            if planet.Hazard then
+                planet.Stardust = planet.Stardust - 1
+            else
+                planet.Stardust = planet.Stardust + planet.TechLevel
+            end
+        end
+    end
+end
+
+return GameServer

--- a/src/Planet.lua
+++ b/src/Planet.lua
@@ -1,0 +1,40 @@
+local Planet = {}
+Planet.__index = Planet
+
+function Planet.new(name)
+    local self = setmetatable({}, Planet)
+    self.Name = name
+    self.Flora = {}
+    self.Stardust = 0
+    self.Hazard = nil
+    self.TechLevel = 1
+    return self
+end
+
+function Planet:Terraform(processor)
+    -- processor could be a table representing tech upgrades
+    self.TechLevel = self.TechLevel + (processor and processor.Level or 1)
+    -- Reset hazard after terraforming
+    self.Hazard = nil
+end
+
+function Planet:AddFlora(flower)
+    table.insert(self.Flora, flower)
+end
+
+function Planet:Harvest()
+    -- Basic stardust yield depends on number of plants and tech level
+    local yield = #self.Flora * self.TechLevel
+    self.Stardust = self.Stardust + yield
+    return yield
+end
+
+function Planet:ApplyHazard(hazard)
+    self.Hazard = hazard
+    -- Hazards reduce yield but may unlock mutations
+    if hazard == "SolarFlare" then
+        self.TechLevel = self.TechLevel + 1 -- unlock mutation
+    end
+end
+
+return Planet

--- a/src/PlayerProfile.lua
+++ b/src/PlayerProfile.lua
@@ -1,0 +1,39 @@
+local Planet = require(script.Parent.Planet)
+
+local PlayerProfile = {}
+PlayerProfile.__index = PlayerProfile
+
+function PlayerProfile.new(player)
+    local self = setmetatable({}, PlayerProfile)
+    self.Player = player
+    self.Planets = {}
+    self.NaniteBuff = 1
+    self.Prestige = 0
+    return self
+end
+
+function PlayerProfile:AddPlanet(name)
+    local planet = Planet.new(name)
+    table.insert(self.Planets, planet)
+    return planet
+end
+
+function PlayerProfile:HarvestAll()
+    local total = 0
+    for _, planet in ipairs(self.Planets) do
+        total = total + planet:Harvest() * self.NaniteBuff
+    end
+    return total
+end
+
+function PlayerProfile:PrestigeReset()
+    self.Prestige = self.Prestige + 1
+    self.NaniteBuff = self.NaniteBuff + 0.1
+    for _, planet in ipairs(self.Planets) do
+        planet.Stardust = 0
+        planet.TechLevel = 1
+        planet.Flora = {}
+    end
+end
+
+return PlayerProfile

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,0 +1,15 @@
+local GameServer = require(script.GameServer)
+
+local server = GameServer.new()
+
+-- Example usage
+local player1 = "Player1"
+local profile1 = server:AddPlayer(player1)
+local planet = profile1:AddPlanet("Nova")
+planet:AddFlora("GlowFern")
+planet:ApplyHazard("SolarFlare")
+
+-- Advance one tick
+server:Tick()
+
+print(player1 .. " stardust:", planet.Stardust)


### PR DESCRIPTION
## Summary
- add a set of Lua modules implementing a basic prototype for the *Terraform Tycoon* idle sci-fi builder concept
- update README with description and module list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c2c9a138c83239c4f893398eb8441